### PR TITLE
Fixed unlinked URL in one of the step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Remember that you need to give this service account appropiate roles!
 ## 💻 Development
 
 ```
-$ git clone https://github.com/cloudliz/nodecloud-gcp-plugin
+$ git clone https://github.com/cloudlibz/nodecloud-gcp-plugin
 $ cd nodecloud-gcp-plugin
 $ npm link
-$ git clone https://github.com/cloudliz/nodecloud
+$ git clone https://github.com/cloudlibz/nodecloud
 $ cd nodecloud
 $ npm link nodecloud-gcp-plugin
 ```


### PR DESCRIPTION
Two of the development steps have<b> 'cloudliz/nodecloud'</b> instead of<b> 'cloudlibz/nodecloud'</b>
Changes on: Line #58, #61

Fix: Wrote correct URL 

## Proposed Changes

  - 'cloudliz/nodecloud'  ----> 'cloudlibz/nodecloud' 
  - 'cloudliz/nodecloud-gcp-plugin'  ----> 'cloudlibz/nodecloud-gcp-plugin' 
