### PR TITLE
Change package name from nodecloud-gcp to nodecloud-gcp-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nodecloud-gcp",
+  "name": "nodecloud-gcp-plugin",
   "version": "1.0.0",
   "description": "GCP Wrapper for NodeCloud Core",
   "main": "index.js",


### PR DESCRIPTION
Fixes #12 
 Change package name from `nodecloud-gcp` to `nodecloud-gcp-plugin` in package.json